### PR TITLE
Add google analytics MCP

### DIFF
--- a/mcpo/config.json
+++ b/mcpo/config.json
@@ -64,6 +64,14 @@
       "args": [
         "freshdesk-mcp"
       ]
+    },
+    "analytics-mcp": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/googleanalytics/google-analytics-mcp.git",
+        "google-analytics-mcp"
+      ]
     }
   }
 }


### PR DESCRIPTION
I added the env variable `GOOGLE_APPLICATION_CREDENTIALS` to sliplane. 
Locally it works like this:
```json
    "analytics-mcp": {
      "command": "uvx",
      "args": [
        "--from",
        "git+https://github.com/googleanalytics/google-analytics-mcp.git",
        "google-analytics-mcp"
      ],
      "env": {
        "GOOGLE_APPLICATION_CREDENTIALS": "/Users/jorgbenesch/.config/google-analytics/credentials.json"
      }
    }
```
So I'm hoping this will work on prod.